### PR TITLE
Overflow when sending performance counters values larger than int.MaxValue

### DIFF
--- a/source/Graphite.System/AppPoolListener.cs
+++ b/source/Graphite.System/AppPoolListener.cs
@@ -40,7 +40,7 @@ namespace Graphite.System
             }
         }
 
-        public int? ReportWorkingSet()
+        public long? ReportWorkingSet()
         {
             // AppPool not found -> is not started -> 0 memory in use.
             if (string.IsNullOrEmpty(this.counterName))
@@ -64,7 +64,7 @@ namespace Graphite.System
             {
                 float? value = this.workingSetListener.ReportValue();
 
-                return value.HasValue ? (int)value.Value : default(int?);
+                return value.HasValue ? (long)value.Value : default(long?);
             }
             catch (InvalidOperationException)
             {
@@ -108,7 +108,7 @@ namespace Graphite.System
             {
                 using (PerformanceCounter counter = new PerformanceCounter("Process", "ID Process", instance, true))
                 {
-                    int val = (int)counter.RawValue;
+                    long val = counter.RawValue;
 
                     if (val == processId)
                     {

--- a/source/Graphite.System/Kernel.cs
+++ b/source/Graphite.System/Kernel.cs
@@ -134,7 +134,7 @@ namespace Graphite.System
 
                 if (value.HasValue)
                 {
-                    channel.Report(config.Key, (int)value.Value);
+                    channel.Report(config.Key, (long)value.Value);
                 }
             };
         }
@@ -153,7 +153,7 @@ namespace Graphite.System
             {
                 if (config.WorkingSet)
                 {
-                    int? value = element.ReportWorkingSet();
+                    long? value = element.ReportWorkingSet();
 
                     if (value.HasValue)
                     {

--- a/source/Graphite/Formatters/GraphiteFormatter.cs
+++ b/source/Graphite/Formatters/GraphiteFormatter.cs
@@ -13,7 +13,7 @@ namespace Graphite.Formatters
                 && (string.IsNullOrWhiteSpace(type) || type.Equals("gauge", StringComparison.OrdinalIgnoreCase));
         }
 
-        public string Format(string key, int value)
+        public string Format(string key, long value)
         {
             return string.Format(
                 "{0} {1} {2}", 

--- a/source/Graphite/Formatters/IMessageFormatter.cs
+++ b/source/Graphite/Formatters/IMessageFormatter.cs
@@ -23,6 +23,6 @@ namespace Graphite.Formatters
         /// <param name="key">The key string.</param>
         /// <param name="value">The reported value.</param>
         /// <returns>The formatted string.</returns>
-        string Format(string key, int value);
+        string Format(string key, long value);
     }
 }

--- a/source/Graphite/Formatters/ISampledMessageFormatter.cs
+++ b/source/Graphite/Formatters/ISampledMessageFormatter.cs
@@ -13,6 +13,6 @@ namespace Graphite.Formatters
         /// <param name="value">The reported value.</param>
         /// <param name="sampling">The sampling factor.</param>
         /// <returns>The formatted string.</returns>
-        string Format(string key, int value, float sampling);
+        string Format(string key, long value, float sampling);
     }
 }

--- a/source/Graphite/Formatters/StatsDCounterFormatter.cs
+++ b/source/Graphite/Formatters/StatsDCounterFormatter.cs
@@ -12,12 +12,12 @@ namespace Graphite.Formatters
                 && type.Equals("counter", StringComparison.OrdinalIgnoreCase);
         }
 
-        public string Format(string key, int magnitude)
+        public string Format(string key, long magnitude)
         {
             return string.Format("{0}:{1}|c", key, magnitude);
         }
 
-        public string Format(string key, int magnitude, float sampling)
+        public string Format(string key, long magnitude, float sampling)
         {
             return string.Format("{0}:{1}|c|@{2}", key, magnitude, sampling);
         }

--- a/source/Graphite/Formatters/StatsDGaugeFormatter.cs
+++ b/source/Graphite/Formatters/StatsDGaugeFormatter.cs
@@ -12,7 +12,7 @@ namespace Graphite.Formatters
                 && type.Equals("gauge", StringComparison.OrdinalIgnoreCase);
         }
 
-        public string Format(string key, int value)
+        public string Format(string key, long value)
         {
             return string.Format("{0}:{1}|g", key, value);
         }

--- a/source/Graphite/Formatters/StatsDTimingFormatter.cs
+++ b/source/Graphite/Formatters/StatsDTimingFormatter.cs
@@ -12,7 +12,7 @@ namespace Graphite.Formatters
                 && type.Equals("timing", StringComparison.OrdinalIgnoreCase);
         }
 
-        public string Format(string key, int value)
+        public string Format(string key, long value)
         {
             return string.Format("{0}:{1:d}|ms", key, value);
         }

--- a/source/Graphite/Infrastructure/IMonitoringChannel.cs
+++ b/source/Graphite/Infrastructure/IMonitoringChannel.cs
@@ -13,7 +13,7 @@ namespace Graphite.Infrastructure
         /// <param name="key">The metric key.</param>
         /// <param name="value">The value.</param>
         /// <returns></returns>
-        bool Report(string key, int value);
+        bool Report(string key, long value);
 
         /// <summary>
         /// Reports the specifed value asynchron, returning a task.
@@ -21,6 +21,6 @@ namespace Graphite.Infrastructure
         /// <param name="key">The metric key.</param>
         /// <param name="value">The value.</param>
         /// <returns></returns>
-        Task<bool> ReportAsync(string key, int value);
+        Task<bool> ReportAsync(string key, long value);
     }
 }

--- a/source/Graphite/Infrastructure/MonitoringChannel.cs
+++ b/source/Graphite/Infrastructure/MonitoringChannel.cs
@@ -41,7 +41,7 @@ namespace Graphite.Infrastructure
         /// <param name="key">The metric key.</param>
         /// <param name="value">The value.</param>
         /// <returns></returns>
-        public bool Report(string key, int value)
+        public bool Report(string key, long value)
         {
             string formattedValue = this.formatter.Format(
                 this.keyBuilder(key),
@@ -56,7 +56,7 @@ namespace Graphite.Infrastructure
         /// <param name="key">The metric key.</param>
         /// <param name="value">The value.</param>
         /// <returns></returns>
-        public Task<bool> ReportAsync(string key, int value)
+        public Task<bool> ReportAsync(string key, long value)
         {
             return Task<bool>.Factory
                 .StartNew(() => this.Report(key, value));

--- a/source/Graphite/Infrastructure/SamplingMonitoringChannel.cs
+++ b/source/Graphite/Infrastructure/SamplingMonitoringChannel.cs
@@ -45,7 +45,7 @@ namespace Graphite.Infrastructure
         /// <param name="key">The metric key.</param>
         /// <param name="value">The value.</param>
         /// <returns></returns>
-        public bool Report(string key, int value)
+        public bool Report(string key, long value)
         {
             string formattedValue = this.formatter.Format(
                 this.keyBuilder(key), 
@@ -61,7 +61,7 @@ namespace Graphite.Infrastructure
         /// <param name="key">The metric key.</param>
         /// <param name="value">The value.</param>
         /// <returns></returns>
-        public Task<bool> ReportAsync(string key, int value)
+        public Task<bool> ReportAsync(string key, long value)
         {
             return Task<bool>.Factory
                 .StartNew(() => this.Report(key, value));

--- a/source/Graphite/MetricsPipe.cs
+++ b/source/Graphite/MetricsPipe.cs
@@ -50,28 +50,28 @@ namespace Graphite
             get { return Helpers.ConvertTicksToMs(this.watch.ElapsedTicks, this.watch.Frequency); }
         }
 
-        internal bool ReportCounter(string key, int value, float sampling = 1)
+        internal bool ReportCounter(string key, long value, float sampling = 1)
         {
             var channel = this.factory.CreateChannel("counter", "statsd", sampling);
 
             return channel.Report(key, value);
         }
 
-        internal bool ReportTiming(string key, int value)
+        internal bool ReportTiming(string key, long value)
         {
             var channel = this.factory.CreateChannel("timing", "statsd");
 
             return channel.Report(key, value);
         }
 
-        internal bool ReportGauge(string key, int value)
+        internal bool ReportGauge(string key, long value)
         {
             var channel = this.factory.CreateChannel("gauge", "statsd");
 
             return channel.Report(key, value);
         }
 
-        internal bool ReportRaw(string key, int value)
+        internal bool ReportRaw(string key, long value)
         {
             var channel = this.factory.CreateChannel("gauge", "graphite");
 

--- a/source/Graphite/MetricsPipeExtensions.cs
+++ b/source/Graphite/MetricsPipeExtensions.cs
@@ -39,7 +39,7 @@ namespace Graphite
         /// <param name="profiler">The profiler.</param>
         /// <param name="key">The key.</param>
         /// <param name="value">The timing value.</param>
-        public static void Timing(this MetricsPipe profiler, string key, int value)
+        public static void Timing(this MetricsPipe profiler, string key, long value)
         {
             if (profiler == null)
                 return;
@@ -54,7 +54,7 @@ namespace Graphite
         /// <param name="key">The key.</param>
         /// <param name="value">The value.</param>
         /// <param name="sampling">Sample by provided value.</param>
-        public static void Count(this MetricsPipe profiler, string key, int value = 1, float sampling = 1)
+        public static void Count(this MetricsPipe profiler, string key, long value = 1, float sampling = 1)
         {
             if (profiler == null)
                 return;
@@ -68,7 +68,7 @@ namespace Graphite
         /// <param name="profiler">The profiler.</param>
         /// <param name="key">The key.</param>
         /// <param name="value">The value.</param>
-        public static void Gauge(this MetricsPipe profiler, string key, int value)
+        public static void Gauge(this MetricsPipe profiler, string key, long value)
         {
             if (profiler == null)
                 return;
@@ -82,7 +82,7 @@ namespace Graphite
         /// <param name="profiler">The profiler.</param>
         /// <param name="key">The metric key.</param>
         /// <param name="value">The value.</param>
-        public static void Raw(this MetricsPipe profiler, string key, int value)
+        public static void Raw(this MetricsPipe profiler, string key, long value)
         {
             if (profiler == null)
                 return;


### PR DESCRIPTION
Hello,
In Kernel.cs (https://github.com/peschuster/graphite-client/blob/master/source/Graphite.System/Kernel.cs#L137), a float value is casted into an int value. This leads to an overflow when reporting values larger than int.MaxValue; the behavior in this case being to report a value equal to int.MinValue. For some counters such as GC gen2 size, this might be problematic.

A best effort fix would be to cast this value to a long, even though it seems that the only use of this is to format the value to send it to Graphite or StatsD, which might be achievable (I'm no expert at the protocol) via a simple float truncation.

Anyway, thanks for your tool, which might be really useful for me as soon as this is fixed !
