### PR TITLE
Added parameters 'entryid' and 'attacheventidtokey' to eventlog section

### DIFF
--- a/source/Graphite.System/App.config
+++ b/source/Graphite.System/App.config
@@ -42,6 +42,14 @@
     <appPool>
       <add key="admin.test.appPool.default" appPoolName="DefaultAppPool" workingSet="true"
         type="gauge" target="statsd" />
+      <add
+        key="eventlog.WAS"
+        protocol="System" source="WAS"  entrytypes="Error, Warning, Information"
+        type="counter" attacheventidtokey="true" target="statsd" />
+      <add
+        key="eventlog.IIS"
+        protocol="System" source="IIS-IISReset"  entrytypes="Error, Warning, Information"
+        type="counter" eventid="3202" target="statsd" />
     </appPool>
   </graphite.system>
 </configuration>

--- a/source/Graphite.System/Configuration/EventlogListenerElement.cs
+++ b/source/Graphite.System/Configuration/EventlogListenerElement.cs
@@ -45,6 +45,16 @@ namespace Graphite.System.Configuration
         internal const string ValuePropertyName = "value";
 
         /// <summary>
+        /// The XML name of the <see cref="EventID"/> property.
+        /// </summary>        
+        internal const string EventIDPropertyName = "eventid";
+
+        /// <summary>
+        /// The XML name of the <see cref="AttachEventIDToKey"/> property.
+        /// </summary>        
+        internal const string AttachEventIDToKeyPropertyName = "attacheventidtokey";
+
+        /// <summary>
         /// The XML name of the <see cref="Sampling"/> property.
         /// </summary>        
         internal const string SamplingPropertyName = "sampling";
@@ -127,6 +137,26 @@ namespace Graphite.System.Configuration
         {
             get { return (int)base[ValuePropertyName]; }
             set { base[ValuePropertyName] = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the EventID.
+        /// </summary>
+        [ConfigurationPropertyAttribute(EventIDPropertyName, IsRequired = false, DefaultValue = null)]
+        public int? EventID
+        {
+            get { return (int?)base[EventIDPropertyName]; }
+            set { base[EventIDPropertyName] = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the 
+        /// </summary>
+        [ConfigurationPropertyAttribute(AttachEventIDToKeyPropertyName, IsRequired = false, DefaultValue = false)]
+        public bool AttachEventIDToKey
+        {
+            get { return (bool)base[AttachEventIDToKeyPropertyName]; }
+            set { base[AttachEventIDToKeyPropertyName] = value; }
         }
 
         /// <summary>

--- a/source/Graphite.System/Kernel.cs
+++ b/source/Graphite.System/Kernel.cs
@@ -198,7 +198,9 @@ namespace Graphite.System
                 config.Category,
                 types,
                 config.Key,
+                config.EventID,
                 config.Value,
+                config.AttachEventIDToKey,
                 channel);
 
             this.listeners.Add(listener);


### PR DESCRIPTION
Hi! This is my first contribution to this project :)

I needed some extra features on eventlog listener, so I've added them.

These two features can be enabled via new parameters on <eventlog> section:

**eventid**: Filter events to be sent to graphite based on their "EventID".

Let's say I need to trace how may times an IIS appPool is recycled manually. This is shown on Event Viewer as source "WAS" / EventID "5079", so I'd need to configure it like this:

```
<add
        key="eventlog.WAS"
        protocol="System" source="WAS"  entrytypes="Error, Warning, Information"
        type="counter" attacheventidtokey="true" target="statsd" />
```

**attacheventidtokey**: Send every different event type as a separate metric. Enabling this flag, the application will attach the "EventID" to the end of the key. This way you 

Let's say I need to count all WAS' Error events. I'd need to configure it like this:

```
<add
        key="eventlog.systemerrors"
        protocol="System" source="WAS"  entrytypes="Error"
        type="counter" attacheventidtokey="true" target="statsd" />
```

Hope you find this as useful as me :)