### PR TITLE
Allow IConfigurationContainer to be passed into StaticMetricsPipeProv…

### DIFF
--- a/source/Graphite/StaticMetricsPipeProvider.cs
+++ b/source/Graphite/StaticMetricsPipeProvider.cs
@@ -42,6 +42,19 @@ namespace Graphite
 
             return result;
         }
+        
+        /// <summary>
+        /// Starts a new MetricsPipe instance.
+        /// </summary>
+        /// <param name="configurationContainer"></param>
+        /// <returns></returns>
+        public MetricsPipe Start(IConfigurationContainer configurationContainer)
+        {
+            var result = new MetricsPipe(configurationContainer, this, StopwatchWrapper.StartNew);
+            Current = result;
+
+            return result;
+        }
 
         /// <summary>
         /// Stops the current MetricsPipe instance.


### PR DESCRIPTION
.Net core doesn't use traditional XML .config files so we needed a way to pass in the configuration programatically. Hope it's OK.