### PR TITLE
Automatically recreate the UDP client after a given time

### DIFF
--- a/source/Graphite/Configuration/ConnectionStringConfigurationBase.cs
+++ b/source/Graphite/Configuration/ConnectionStringConfigurationBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Graphite.Configuration
@@ -24,6 +25,11 @@ namespace Graphite.Configuration
         public string PrefixKey { get; private set; }
 
         /// <summary>
+        /// Gets the time before renewing the socket, when using UDP protocol.
+        /// </summary>
+        public TimeSpan Lifetime { get; private set; }
+
+        /// <summary>
         /// Parses connection string to properties.
         /// </summary>
         /// <param name="connectionString"></param>
@@ -37,7 +43,7 @@ namespace Graphite.Configuration
                     .Split(';')
                     .Select(x => x.Split(new[] { '=' }, 2))
                     .ToDictionary(
-                        x => x.First().ToLowerInvariant(), 
+                        x => x.First().ToLowerInvariant(),
                         x => x.Skip(1).FirstOrDefault());
 
                 string value;
@@ -58,6 +64,14 @@ namespace Graphite.Configuration
                 if (values.TryGetValue("prefixkey", out value))
                 {
                     this.PrefixKey = value;
+                }
+
+                if (values.TryGetValue("lifetime", out value))
+                {
+                    if (TimeSpan.TryParse(value, out TimeSpan temp))
+                    {
+                        this.Lifetime = temp;
+                    }
                 }
             }
 

--- a/source/Graphite/Configuration/ConnectionStringConfigurationBase.cs
+++ b/source/Graphite/Configuration/ConnectionStringConfigurationBase.cs
@@ -68,7 +68,9 @@ namespace Graphite.Configuration
 
                 if (values.TryGetValue("lifetime", out value))
                 {
-                    if (TimeSpan.TryParse(value, out TimeSpan temp))
+                    TimeSpan temp;
+
+                    if (TimeSpan.TryParse(value, out temp))
                     {
                         this.Lifetime = temp;
                     }

--- a/source/Graphite/Configuration/GraphiteElement.cs
+++ b/source/Graphite/Configuration/GraphiteElement.cs
@@ -1,4 +1,5 @@
-﻿using System.Configuration;
+﻿using System;
+using System.Configuration;
 using System.Net;
 
 namespace Graphite.Configuration
@@ -27,6 +28,11 @@ namespace Graphite.Configuration
         /// The XML name of the <see cref="PrefixKey"/> property.
         /// </summary>    
         internal const string PrefixKeyPropertyName = "prefixKey";
+
+        /// <summary>
+        /// The XML name of the <see cref="Lifetime"/> property
+        /// </summary>
+        internal const string LifetimePropertyName = "lifetime";
 
         /// <summary>
         /// Gets or sets the port number.
@@ -66,6 +72,16 @@ namespace Graphite.Configuration
         {
             get { return (string)base[PrefixKeyPropertyName]; }
             set { base[PrefixKeyPropertyName] = value; }
+        }
+
+        /// <summary>
+        /// When using UDP protocol, the time before renewing the socket
+        /// </summary>        
+        [ConfigurationProperty(LifetimePropertyName, IsRequired = false)]
+        public TimeSpan Lifetime
+        {
+            get { return (TimeSpan)base[LifetimePropertyName]; }
+            set { base[LifetimePropertyName] = value; }
         }
     }
 }

--- a/source/Graphite/Configuration/IGraphiteConfiguration.cs
+++ b/source/Graphite/Configuration/IGraphiteConfiguration.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net;
 
 namespace Graphite.Configuration
@@ -26,5 +27,10 @@ namespace Graphite.Configuration
         /// Gets the common prefix key.
         /// </summary>        
         string PrefixKey { get; }
+
+        /// <summary>
+        /// Gets the time before renewing the socket, when using UDP protocol
+        /// </summary>
+        TimeSpan Lifetime { get; }
     }
 }

--- a/source/Graphite/Configuration/IStatsDConfiguration.cs
+++ b/source/Graphite/Configuration/IStatsDConfiguration.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Graphite.Configuration
 {
     /// <summary>
@@ -19,5 +21,10 @@ namespace Graphite.Configuration
         /// Gets the common prefix key.
         /// </summary>        
         string PrefixKey { get; }
+
+        /// <summary>
+        /// Gets the time before renewing the socket, when using UDP protocol
+        /// </summary>
+        TimeSpan Lifetime { get; }
     }
 }

--- a/source/Graphite/Configuration/StatsDElement.cs
+++ b/source/Graphite/Configuration/StatsDElement.cs
@@ -1,4 +1,5 @@
-﻿using System.Configuration;
+﻿using System;
+using System.Configuration;
 
 namespace Graphite.Configuration
 {
@@ -21,6 +22,11 @@ namespace Graphite.Configuration
         /// The XML name of the <see cref="PrefixKey"/> property.
         /// </summary> 
         internal const string PrefixKeyPropertyName = "prefixKey";
+
+        /// <summary>
+        /// The XML name of the <see cref="Lifetime"/> property
+        /// </summary>
+        internal const string LifetimePropertyName = "lifetime";
 
         /// <summary>
         /// Gets or sets the port number.
@@ -50,6 +56,16 @@ namespace Graphite.Configuration
         {
             get { return (string)base[PrefixKeyPropertyName]; }
             set { base[PrefixKeyPropertyName] = value; }
+        }
+
+        /// <summary>
+        /// The time before renewing the socket
+        /// </summary>        
+        [ConfigurationProperty(LifetimePropertyName, IsRequired = false)]
+        public TimeSpan Lifetime
+        {
+            get { return (TimeSpan)base[LifetimePropertyName]; }
+            set { base[LifetimePropertyName] = value; }
         }
     }
 }

--- a/source/Graphite/Graphite.csproj
+++ b/source/Graphite/Graphite.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Formatters\StatsDSetFormatter.cs" />
     <Compile Include="Formatters\StatsDGaugeFormatter.cs" />
     <Compile Include="Formatters\StatsDTimingFormatter.cs" />
+    <Compile Include="Infrastructure\AutoRefreshPipe.cs" />
     <Compile Include="Infrastructure\IMonitoringChannel.cs" />
     <Compile Include="Infrastructure\ISamplingPipe.cs" />
     <Compile Include="IMetricsPipeProvider.cs" />

--- a/source/Graphite/Infrastructure/AutoRefreshPipe.cs
+++ b/source/Graphite/Infrastructure/AutoRefreshPipe.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Threading;
+
+namespace Graphite.Infrastructure
+{
+    internal class AutoRefreshPipe : IPipe, IDisposable
+    {
+        private readonly Func<IPipe> pipeFactory;
+        private readonly TimeSpan delay;
+
+        private DateTime lastUpdate;
+        private IPipe innerPipe;
+
+        public AutoRefreshPipe(Func<IPipe> pipeFactory, TimeSpan delay)
+        {
+            this.pipeFactory = pipeFactory;
+            this.innerPipe = pipeFactory();
+            this.delay = delay;
+            this.lastUpdate = DateTime.UtcNow;
+        }
+
+        public bool Send(string message)
+        {
+            this.RefreshPipeIfNeeded();
+
+            return this.innerPipe.Send(message);
+        }
+
+        public bool Send(string[] messages)
+        {
+            this.RefreshPipeIfNeeded();
+
+            return this.innerPipe.Send(messages);
+        }
+
+        public void Dispose()
+        {
+            this.DisposePipe(this.innerPipe);
+        }
+
+        private void RefreshPipeIfNeeded()
+        {
+            if (this.delay > TimeSpan.Zero && DateTime.UtcNow - this.lastUpdate >= this.delay)
+            {
+                var oldPipe = Interlocked.Exchange(ref this.innerPipe, this.pipeFactory());
+                this.lastUpdate = DateTime.UtcNow;
+                this.DisposePipe(oldPipe);
+            }
+        }
+
+        private void DisposePipe(IPipe pipe)
+        {
+            var disposablePipe = pipe as IDisposable;
+
+            disposablePipe?.Dispose();
+        }
+    }
+}

--- a/source/Graphite/Infrastructure/UdpPipe.cs
+++ b/source/Graphite/Infrastructure/UdpPipe.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Net;
 using System.Net.Sockets;
 using System.Text;
 
@@ -12,11 +11,11 @@ namespace Graphite.Infrastructure
 
         private bool disposed;
 
-        public UdpPipe(IPAddress address, int port)
+        public UdpPipe(string address, int port)
         {
             this.udpClient = new UdpClient();
 
-            this.udpClient.Connect(new IPEndPoint(address, port));
+            this.udpClient.Connect(address, port);
         }
 
         public bool Send(string message)
@@ -36,7 +35,7 @@ namespace Graphite.Infrastructure
 
             return this.CoreSend(data);
         }
-  
+
         private bool CoreSend(byte[] data)
         {
             try

--- a/source/MSBuild.Graphite/Tasks/Graphite.cs
+++ b/source/MSBuild.Graphite/Tasks/Graphite.cs
@@ -24,15 +24,15 @@ namespace MSBuild.Graphite.Tasks
         public int Port { get; set; }
 
         [Required]
-        public string Transport 
+        public string Transport
         {
             get { return this.transport.ToString(); }
             set { this.transport = (TransportType)Enum.Parse(typeof(TransportType), value); }
         }
 
-        TransportType IGraphiteConfiguration.Transport 
-        { 
-            get { return this.transport; } 
+        TransportType IGraphiteConfiguration.Transport
+        {
+            get { return this.transport; }
         }
 
         public string PrefixKey { get; set; }
@@ -42,12 +42,14 @@ namespace MSBuild.Graphite.Tasks
 
         public int Value { get; set; }
 
+        public TimeSpan Lifetime { get; set; }
+
         public override bool Execute()
         {
             using (var channelFactory = new ChannelFactory(this, null))
             {
                 IMonitoringChannel channel = channelFactory.CreateChannel(
-                    "gauge", 
+                    "gauge",
                     "graphite");
 
                 channel.Report(this.Key, this.Value);

--- a/source/MSBuild.Graphite/Tasks/StatsD.cs
+++ b/source/MSBuild.Graphite/Tasks/StatsD.cs
@@ -30,6 +30,8 @@ namespace MSBuild.Graphite.Tasks
         [Required]
         public MetricType Type { get; set; }
 
+        public TimeSpan Lifetime { get; set; }
+
         public override bool Execute()
         {
             using (var channelFactory = new ChannelFactory(null, this))


### PR DESCRIPTION
It makes the UDP pipe more resilient to DNS changes or socket errors

It also contributes to https://github.com/peschuster/graphite-client/issues/27